### PR TITLE
Add unit tests for pure functions and AsocialBookmark class

### DIFF
--- a/test/asocial-bookmark.test.ts
+++ b/test/asocial-bookmark.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, afterEach } from "vitest";
+import path from "node:path";
+import fs from "node:fs";
+import os from "node:os";
+import { fileURLToPath } from "node:url";
+import { createBookmarkFilePath, isAsocialBookmarkItem, AsocialBookmark } from "../src/asocial-bookmark.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const fixturesDir = path.join(__dirname, "fixtures");
+
+describe("createBookmarkFilePath", () => {
+    it("should replace :year/:month/:day placeholders", () => {
+        const date = new Date("2023-07-15T00:00:00.000Z");
+        const result = createBookmarkFilePath("data/:year/:month/:day/index.json", date);
+        expect(result).toBe("data/2023/07/15/index.json");
+    });
+
+    it("should replace :year/:month placeholders without :day", () => {
+        const date = new Date("2019-01-10T00:00:00.000Z");
+        const result = createBookmarkFilePath("data/:year/:month/index.json", date);
+        expect(result).toBe("data/2019/01/index.json");
+    });
+
+    it("should handle different dates correctly", () => {
+        const date = new Date("2018-12-25T00:00:00.000Z");
+        const result = createBookmarkFilePath("data/:year/:month/index.json", date);
+        expect(result).toBe("data/2018/12/index.json");
+    });
+});
+
+describe("isAsocialBookmarkItem", () => {
+    it("should return true for a valid item", () => {
+        const item = {
+            title: "Example",
+            url: "https://example.com",
+            content: "description",
+            tags: ["tag1"],
+            date: "2019-01-01T00:00:00.000Z",
+        };
+        expect(isAsocialBookmarkItem(item)).toBe(true);
+    });
+
+    it("should return false when title is missing", () => {
+        const item = {
+            url: "https://example.com",
+            content: "description",
+        };
+        expect(isAsocialBookmarkItem(item)).toBe(false);
+    });
+
+    it("should return false when url is missing", () => {
+        const item = {
+            title: "Example",
+            content: "description",
+        };
+        expect(isAsocialBookmarkItem(item)).toBe(false);
+    });
+
+    it("should return false when content is missing", () => {
+        const item = {
+            title: "Example",
+            url: "https://example.com",
+        };
+        expect(isAsocialBookmarkItem(item)).toBe(false);
+    });
+});
+
+describe("AsocialBookmark", () => {
+    describe("getBookmarksAt", () => {
+        it("should return bookmarks from fixtures", async () => {
+            const bookmark = new AsocialBookmark({
+                local: { cwd: fixturesDir },
+            });
+            const items = await bookmark.getBookmarksAt(new Date("2019-01-15T00:00:00.000Z"));
+            expect(Array.isArray(items)).toBe(true);
+            expect(items.length).toBeGreaterThan(0);
+            expect(items.every(isAsocialBookmarkItem)).toBe(true);
+        });
+
+        it("should return empty array for non-existent date", async () => {
+            const bookmark = new AsocialBookmark({
+                local: { cwd: fixturesDir },
+            });
+            const items = await bookmark.getBookmarksAt(new Date("2099-01-01T00:00:00.000Z"));
+            expect(items).toEqual([]);
+        });
+    });
+
+    describe("CRUD operations", () => {
+        let tmpDir: string;
+
+        afterEach(() => {
+            if (tmpDir) {
+                fs.rmSync(tmpDir, { recursive: true, force: true });
+            }
+        });
+
+        it("should updateBookmark, getBookmark, and deleteBookmark", async () => {
+            tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "asocial-bookmark-test-"));
+            const bookmark = new AsocialBookmark({
+                local: { cwd: tmpDir },
+            });
+            const testItem = {
+                title: "Test Bookmark",
+                url: "https://example.com/test",
+                content: "Test content",
+                tags: ["test"],
+                date: "2024-03-15T12:00:00.000Z",
+            };
+
+            // Create
+            await bookmark.updateBookmark(testItem);
+
+            // Read
+            const found = await bookmark.getBookmark({
+                url: "https://example.com/test",
+                date: "2024-03-15T12:00:00.000Z",
+            });
+            expect(found.title).toBe("Test Bookmark");
+            expect(found.url).toBe("https://example.com/test");
+            expect(found.content).toBe("Test content");
+            expect(found.tags).toEqual(["test"]);
+
+            // Delete
+            await bookmark.deleteBookmark({
+                url: "https://example.com/test",
+                date: "2024-03-15T12:00:00.000Z",
+            });
+
+            // Verify deleted
+            await expect(
+                bookmark.getBookmark({
+                    url: "https://example.com/test",
+                    date: "2024-03-15T12:00:00.000Z",
+                })
+            ).rejects.toThrow("Not found item");
+        });
+    });
+});

--- a/test/parse-mydata.test.ts
+++ b/test/parse-mydata.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { parseComment } from "../src/cli/hatebu-lib/parse-mydata.js";
+
+describe("parseComment", () => {
+    it("should parse tags and comment", () => {
+        const result = parseComment("[tag1][tag2] comment text");
+        expect(result.tags).toEqual(["tag1", "tag2"]);
+        expect(result.comment).toBe("comment text");
+    });
+
+    it("should return empty tags when no tags present", () => {
+        const result = parseComment("just a comment");
+        expect(result.tags).toEqual([]);
+        expect(result.comment).toBe("just a comment");
+    });
+
+    it("should parse tags only with empty comment", () => {
+        const result = parseComment("[tag]");
+        expect(result.tags).toEqual(["tag"]);
+        expect(result.comment).toBe("");
+    });
+
+    it("should not treat brackets in the middle of text as tags", () => {
+        const result = parseComment("[tag1] text with [bracket] in it");
+        expect(result.tags).toEqual(["tag1"]);
+        expect(result.comment).toBe("text with [bracket] in it");
+    });
+
+    it("should handle empty string", () => {
+        const result = parseComment("");
+        expect(result.tags).toEqual([]);
+        expect(result.comment).toBe("");
+    });
+});


### PR DESCRIPTION
## Summary

Add unit tests for pure functions (`createBookmarkFilePath`, `isAsocialBookmarkItem`, `parseComment`) and `AsocialBookmark` class CRUD operations to improve test coverage from 2 tests to 17 tests.

## Changes

- Add `test/asocial-bookmark.test.ts` with tests for:
  - `createBookmarkFilePath`: placeholder replacement with different dates
  - `isAsocialBookmarkItem`: valid items and missing required properties
  - `AsocialBookmark.getBookmarksAt`: reading from fixtures and handling non-existent dates
  - `AsocialBookmark` CRUD flow: updateBookmark → getBookmark → deleteBookmark using a temp directory
- Add `test/parse-mydata.test.ts` with tests for:
  - `parseComment`: tags + comment, no tags, tags only, mid-text brackets, empty string

## Breaking Changes

None

## Test Plan

Run `pnpm test` — all 17 tests pass (3 test files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)