### PR TITLE
fix!: reject promise on fetch failure instead of swallowing errors

### DIFF
--- a/test/asocial-bookmark.test.ts
+++ b/test/asocial-bookmark.test.ts
@@ -78,12 +78,13 @@ describe("AsocialBookmark", () => {
             expect(items.every(isAsocialBookmarkItem)).toBe(true);
         });
 
-        it("should return empty array for non-existent date", async () => {
+        it("should reject for non-existent date", async () => {
             const bookmark = new AsocialBookmark({
                 local: { cwd: fixturesDir },
             });
-            const items = await bookmark.getBookmarksAt(new Date("2099-01-01T00:00:00.000Z"));
-            expect(items).toEqual([]);
+            await expect(
+                bookmark.getBookmarksAt(new Date("2099-01-01T00:00:00.000Z"))
+            ).rejects.toThrow();
         });
     });
 


### PR DESCRIPTION
## Summary

Remove try/catch blocks in `AsocialBookmark` class methods that were silently swallowing errors and returning empty defaults. Methods now properly reject their promises on failure, allowing callers to handle errors appropriately.

## Changes

- Remove try/catch from `getBookmarksAt`, `getTags`, `getBookmarks`, `getBookmark`, `updateTags`, and `updateBookmark`
- `updateBookmark` and `updateTags` use `.catch(() => [])` fallback only for initial creation (file not yet existing)
- `getBookmark` uses `throw` instead of `Promise.reject()`
- Update test to expect rejection for non-existent date instead of empty array

## Breaking Changes

- `getBookmarksAt` now rejects instead of returning `[]` on failure
- `getTags` now rejects instead of returning `[]` on failure
- `getBookmarks` now rejects instead of returning `[]` on failure
- `updateTags` now rejects on write failure instead of silently returning
- `updateBookmark` now rejects on write failure instead of silently returning

## Test Plan

- Run `pnpm test` to verify all 17 tests pass
- Verify `getBookmarksAt` rejects for non-existent dates
- Verify CRUD operations still work (updateBookmark handles missing files for initial creation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
